### PR TITLE
Add generic types to Nav links

### DIFF
--- a/src/organisms/Navbar/Navbar.stories.tsx
+++ b/src/organisms/Navbar/Navbar.stories.tsx
@@ -32,7 +32,7 @@ export default {
 } as ComponentMeta<typeof Navbar>;
 
 // Create a master template for mapping args to render the Navbar component
-const Template: Story<NavbarProps> = (args) => <Navbar {...args}></Navbar>;
+const Template: Story<NavbarProps<string>> = (args) => <Navbar {...args}></Navbar>;
 
 export const Default = Template.bind({});
 Default.args = {};

--- a/src/organisms/Navbar/Navbar.stories.tsx
+++ b/src/organisms/Navbar/Navbar.stories.tsx
@@ -32,7 +32,9 @@ export default {
 } as ComponentMeta<typeof Navbar>;
 
 // Create a master template for mapping args to render the Navbar component
-const Template: Story<NavbarProps<string>> = (args) => <Navbar {...args}></Navbar>;
+const Template: Story<NavbarProps<string>> = (args) => (
+    <Navbar {...args}></Navbar>
+);
 
 export const Default = Template.bind({});
 Default.args = {};

--- a/src/organisms/Navbar/Navbar.tsx
+++ b/src/organisms/Navbar/Navbar.tsx
@@ -7,7 +7,7 @@ import { NavbarProps } from ".";
 import HeaderSiteSwitcher from "./HeaderSiteSwitcher";
 import navBg from "./nav-bg.png";
 
-const Navbar = <Link extends string,>({
+const Navbar = <Link extends string>({
     children,
     links,
     activeLink,

--- a/src/organisms/Navbar/Navbar.tsx
+++ b/src/organisms/Navbar/Navbar.tsx
@@ -7,19 +7,19 @@ import { NavbarProps } from ".";
 import HeaderSiteSwitcher from "./HeaderSiteSwitcher";
 import navBg from "./nav-bg.png";
 
-const Navbar: React.FC<NavbarProps> = ({
+const Navbar = <Link extends string,>({
     children,
     links,
     activeLink,
     href,
     onClickLink,
-}) => {
+}: NavbarProps<Link>): JSX.Element => {
     return (
         <NavbarBackground>
             <NavbarContent>
                 <HeaderSiteSwitcher href={href} />
                 <NavLinks>
-                    {links.map((link: string) => (
+                    {links.map((link) => (
                         <NavLink
                             selected={link === activeLink}
                             key={link}

--- a/src/organisms/Navbar/Navbar.types.ts
+++ b/src/organisms/Navbar/Navbar.types.ts
@@ -5,7 +5,7 @@ export interface NavbarProps<Link extends string> {
     href: string;
     onClickLink?: (link: Link) => void;
     children?: React.ReactNode;
-};
+}
 
 export interface HeaderSiteSwitcherProps {
     className?: string;

--- a/src/organisms/Navbar/Navbar.types.ts
+++ b/src/organisms/Navbar/Navbar.types.ts
@@ -1,10 +1,11 @@
 // Generated with util/create-component.js
-export interface NavbarProps {
-    links: string[];
-    activeLink: string;
+export interface NavbarProps<Link extends string> {
+    links: Link[];
+    activeLink: Link;
     href: string;
-    onClickLink?: (link: string) => void;
-}
+    onClickLink?: (link: Link) => void;
+    children?: React.ReactNode;
+};
 
 export interface HeaderSiteSwitcherProps {
     className?: string;


### PR DESCRIPTION
## Changelog

- Add generic types to navbar props
- This allows you to pass a Link type and be certain of the type getting passed into onClick and create mappings later that dont error out on typescript

## Demo
```
type Route = 'Tokens' | 'Pools' | 'Stake' | 'Bridge' | 'Portfolio'

const routeMap: Record<Route, string> = {
    'Tokens': '/',
    'Pools': '/pools',
    'Stake': '/stake',
    'Portfolio': '/portfolio',
    'Bridge': '/bridge',
}
<Navbar
    links={['Tokens', 'Portfolio', 'Stake', 'Bridge', 'Portfolio']}
    onClickLink={(link: Route) => router.push(routeMap[link])}
    activeLink={route}
    href="/"
/>
```
would work and infer that links is of type Route[] and route is Route, where as previously you would not be able to map on the link since type any cant be mapped to a record.

## Notes
Its a small addition but makes it a bit nicer to use.