### PR TITLE
fix: ensure links have display none when dropdown is closed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tracer-protocol/tracer-ui",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "main": "build/index.js",
     "module": "build/index.esm.js",
     "files": [

--- a/src/organisms/Navbar/HeaderSiteSwitcher.tsx
+++ b/src/organisms/Navbar/HeaderSiteSwitcher.tsx
@@ -41,6 +41,10 @@ const DropdownContent = styled.div`
     transition: 0.3s;
 `;
 
+const DropdownItemContainer = styled.div`
+    display: none;
+`;
+
 const Icons = styled.div`
     margin-top: 3rem;
 `;
@@ -102,6 +106,10 @@ const Dropdown = styled.div`
             opacity: 1;
             transition: opacity 0.5s ease;
             transition-delay: 0.35s;
+        }
+
+        ${DropdownItemContainer} {
+            display: block;
         }
     }
 `;
@@ -176,43 +184,47 @@ const NavDropdown = styled(({ className, href }) => {
             <Dropdown className={`${open ? "open" : ""}`}>
                 <Backdrop />
                 <DropdownContent>
-                    <NavDropdownOption
-                        href={"https://vote.tracer.finance/#/"}
-                        label={"Perpetual Pools"}
-                        boxColor={"purple"}
-                    />
-                    <NavDropdownOption
-                        href={"https://vote.tracer.finance/#/"}
-                        label={"Governance"}
-                        boxColor={"green"}
-                    />
-                    <NavDropdownOption
-                        href={"https://vote.tracer.finance/#/"}
-                        label={"Documentation"}
-                        boxColor={"blue"}
-                    />
-                    <Icons>
-                        {icons.map((icon, i) => (
-                            <ClickableIcon
-                                href={icon.href}
-                                rel="noreferrer"
-                                target="_blank"
-                                key={i}
-                            >
-                                <span>
-                                    <SocialIcon
-                                        name={icon.logo as IconProps["name"]}
-                                        size="sm"
-                                    />
-                                </span>
-                                <span>
-                                    <Text.Body fontFamily="heading">
-                                        {icon.text}
-                                    </Text.Body>
-                                </span>
-                            </ClickableIcon>
-                        ))}
-                    </Icons>
+                    <DropdownItemContainer>
+                        <NavDropdownOption
+                            href={"https://vote.tracer.finance/#/"}
+                            label={"Perpetual Pools"}
+                            boxColor={"purple"}
+                        />
+                        <NavDropdownOption
+                            href={"https://vote.tracer.finance/#/"}
+                            label={"Governance"}
+                            boxColor={"green"}
+                        />
+                        <NavDropdownOption
+                            href={"https://vote.tracer.finance/#/"}
+                            label={"Documentation"}
+                            boxColor={"blue"}
+                        />
+                        <Icons>
+                            {icons.map((icon, i) => (
+                                <ClickableIcon
+                                    href={icon.href}
+                                    rel="noreferrer"
+                                    target="_blank"
+                                    key={i}
+                                >
+                                    <span>
+                                        <SocialIcon
+                                            name={
+                                                icon.logo as IconProps["name"]
+                                            }
+                                            size="sm"
+                                        />
+                                    </span>
+                                    <span>
+                                        <Text.Body fontFamily="heading">
+                                            {icon.text}
+                                        </Text.Body>
+                                    </span>
+                                </ClickableIcon>
+                            ))}
+                        </Icons>
+                    </DropdownItemContainer>
                 </DropdownContent>
             </Dropdown>
         </div>


### PR DESCRIPTION
## Changelog

- Added a container to apply `display: none` to the links when the dropdown is closed.  There was a bug where the dropdown was closed but the links were still clickable even though they were not visible

## Demo
https://www.loom.com/share/5d79e19cc5e944b38e968e29a2675eac
