### PR TITLE
Add icon rotation from FontAwesomeIconProps

### DIFF
--- a/src/atoms/Icon/Icon.stories.tsx
+++ b/src/atoms/Icon/Icon.stories.tsx
@@ -54,6 +54,11 @@ export default {
             },
             defaultValue: "primary",
         },
+        rotation: {
+            control: {
+                type: "number",
+            },
+        },
     },
 } as ComponentMeta<typeof Icon>;
 

--- a/src/atoms/Icon/Icon.tsx
+++ b/src/atoms/Icon/Icon.tsx
@@ -12,6 +12,7 @@ const Icon: React.FC<IconProps> = ({
     color = "primary",
     className,
     id,
+    rotation
 }) => {
     const icon = tracerIcons[name];
     const theme = useTheme();
@@ -52,6 +53,7 @@ const Icon: React.FC<IconProps> = ({
             size={size}
             className={className}
             id={id}
+            rotation={rotation}
         />
     );
 };

--- a/src/atoms/Icon/Icon.tsx
+++ b/src/atoms/Icon/Icon.tsx
@@ -12,7 +12,7 @@ const Icon: React.FC<IconProps> = ({
     color = "primary",
     className,
     id,
-    rotation
+    rotation,
 }) => {
     const icon = tracerIcons[name];
     const theme = useTheme();

--- a/src/atoms/Icon/Icon.types.ts
+++ b/src/atoms/Icon/Icon.types.ts
@@ -2,13 +2,16 @@
 
 import { tracerIcons } from "./iconsConfig";
 import { SizeProp } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIconProps } from "@fortawesome/react-fontawesome";
 
+// NOTE we can accept all FontAwesomeIconProps here with extends FontAwesomeIconProps
 export interface IconProps {
     name: keyof typeof tracerIcons;
     color?: IconColor;
     size?: SizeProp;
     className?: string;
     id?: string;
+    rotation?: FontAwesomeIconProps['rotation']
 }
 
 export type IconColor =

--- a/src/atoms/Icon/Icon.types.ts
+++ b/src/atoms/Icon/Icon.types.ts
@@ -11,7 +11,7 @@ export interface IconProps {
     size?: SizeProp;
     className?: string;
     id?: string;
-    rotation?: FontAwesomeIconProps['rotation']
+    rotation?: FontAwesomeIconProps["rotation"];
 }
 
 export type IconColor =

--- a/src/atoms/Icon/iconsConfig.ts
+++ b/src/atoms/Icon/iconsConfig.ts
@@ -14,6 +14,8 @@ import {
     faGlobeAmericas,
     faExclamationCircle,
     faInfoCircle,
+    faArrowCircleDown,
+    faArrowDown
 } from "@fortawesome/free-solid-svg-icons";
 
 import {
@@ -41,4 +43,6 @@ export const tracerIcons = {
     exclamationCircle: faExclamationCircle,
     "info-circle": faInfoCircle,
     clipboard: faClipboard,
+    'arrow-circle-down': faArrowCircleDown,
+    'arrow-down': faArrowDown
 };

--- a/src/atoms/Icon/iconsConfig.ts
+++ b/src/atoms/Icon/iconsConfig.ts
@@ -15,7 +15,7 @@ import {
     faExclamationCircle,
     faInfoCircle,
     faArrowCircleDown,
-    faArrowDown
+    faArrowDown,
 } from "@fortawesome/free-solid-svg-icons";
 
 import {
@@ -43,6 +43,6 @@ export const tracerIcons = {
     exclamationCircle: faExclamationCircle,
     "info-circle": faInfoCircle,
     clipboard: faClipboard,
-    'arrow-circle-down': faArrowCircleDown,
-    'arrow-down': faArrowDown
+    "arrow-circle-down": faArrowCircleDown,
+    "arrow-down": faArrowDown,
 };


### PR DESCRIPTION
## Changelog

- Extend IconProps to include FontAwesomeProps rotation
- add arrow down icons

## Demo

https://www.loom.com/share/0c110921c5114a89a07bf6a001f41cf0

## Notes

We could include all Fontawesome props since most of them are optional but wanted to get your thoughts