### PR TITLE
Add Tracer UI Footer Component

### DIFF
--- a/src/atoms/Icon/iconsConfig.ts
+++ b/src/atoms/Icon/iconsConfig.ts
@@ -4,6 +4,7 @@ import {
     faClipboard,
 } from "@fortawesome/free-regular-svg-icons";
 import {
+    faBook,
     faLock,
     faUnlock,
     faSearch,
@@ -24,6 +25,7 @@ import {
 } from "@fortawesome/free-brands-svg-icons";
 
 export const tracerIcons = {
+    book: faBook,
     "check-circle": faCheckCircle,
     "check-circle-solid": faCheckCircleSolid,
     circle: faCircle,

--- a/src/organisms/Footer/Footer.stories.tsx
+++ b/src/organisms/Footer/Footer.stories.tsx
@@ -1,7 +1,6 @@
 // Generated with util/create-component.js
 import React from "react";
 import Footer from "./Footer";
-import { FooterProps } from "./Footer.types";
 import { ComponentMeta, Story } from "@storybook/react";
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
@@ -20,7 +19,7 @@ export default {
 } as ComponentMeta<typeof Footer>;
 
 // Create a master template for mapping args to render the Footer component
-const Template: Story<FooterProps> = (args) => <Footer {...args}></Footer>;
+const Template: Story = (args) => <Footer {...args}></Footer>;
 
 // Reuse that template for creating different stories
 export const Default = Template.bind({});

--- a/src/organisms/Footer/Footer.stories.tsx
+++ b/src/organisms/Footer/Footer.stories.tsx
@@ -2,20 +2,18 @@
 import React from "react";
 import Footer from "./Footer";
 import { ComponentMeta, Story } from "@storybook/react";
-import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
 
 export default {
-  title: "organisms/Footer",
-  component: Footer,
-  parameters: {
-    layout: "fullscreen",
-    viewport: {
-      viewports: INITIAL_VIEWPORTS,
+    title: "organisms/Footer",
+    component: Footer,
+    parameters: {
+        layout: "fullscreen",
+        viewport: {
+            viewports: INITIAL_VIEWPORTS,
+        },
     },
-  },
-  argTypes: {
-
-  },
+    argTypes: {},
 } as ComponentMeta<typeof Footer>;
 
 // Create a master template for mapping args to render the Footer component
@@ -23,5 +21,4 @@ const Template: Story = (args) => <Footer {...args}></Footer>;
 
 // Reuse that template for creating different stories
 export const Default = Template.bind({});
-Default.args = {
-}
+Default.args = {};

--- a/src/organisms/Footer/Footer.stories.tsx
+++ b/src/organisms/Footer/Footer.stories.tsx
@@ -1,0 +1,28 @@
+// Generated with util/create-component.js
+import React from "react";
+import Footer from "./Footer";
+import { FooterProps } from "./Footer.types";
+import { ComponentMeta, Story } from "@storybook/react";
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+
+export default {
+  title: "organisms/Footer",
+  component: Footer,
+  parameters: {
+    layout: "fullscreen",
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+    },
+  },
+  argTypes: {
+
+  },
+} as ComponentMeta<typeof Footer>;
+
+// Create a master template for mapping args to render the Footer component
+const Template: Story<FooterProps> = (args) => <Footer {...args}></Footer>;
+
+// Reuse that template for creating different stories
+export const Default = Template.bind({});
+Default.args = {
+}

--- a/src/organisms/Footer/Footer.tsx
+++ b/src/organisms/Footer/Footer.tsx
@@ -3,9 +3,8 @@ import React from "react";
 import { Icon } from "../../atoms";
 import styled from "styled-components";
 import { device } from "../../helpers";
-import { FooterProps } from "./Footer.types";
 
-const Footer: React.FC<FooterProps> = () => {
+const Footer: React.FC = () => {
     const copyrightYear = new Date().getFullYear();
     return (
         <FooterContainer data-testid="Footer">

--- a/src/organisms/Footer/Footer.tsx
+++ b/src/organisms/Footer/Footer.tsx
@@ -21,7 +21,7 @@ const Footer: React.FC = () => {
                 <Link href="https://twitter.com/TracerDAO" target="_blank" rel="noreferrer">
                     <Icon name="twitter" size="lg" />
                 </Link>
-                <Link href="https://github.com/tracer-protocol/perpetual-pools-contracts" target="_blank" rel="noreferrer">
+                <Link href="https://github.com/tracer-protocol" target="_blank" rel="noreferrer">
                     <Icon name="github" size="lg" />
                 </Link>
                 <Link href="https://discord.com/invite/kddBUqDVVb" target="_blank" rel="noreferrer">
@@ -33,7 +33,7 @@ const Footer: React.FC = () => {
                 <Link href="https://tracer.finance/privacy-policy#terms-of-use" target="_blank" rel="noopener noreferrer">Terms of Use</Link>
                 <Link href="https://tracer.finance/privacy-policy#interfaces-disclaimer"  target="_blank" rel="noopener noreferrer">Disclaimer</Link>
                 <Link href="https://gateway.pinata.cloud/ipfs/QmS161WXV2bEAWUtdecfS5FYPmHQZdhNnjVFAwQ5FTX3og" target="_blank" rel="noopener noreferrer">Participation Agreement</Link>
-                <Link href="https://docs.tracer.finance/audits-and-security/perpetual-pools" target="_blank" rel="noopener noreferrer">Security Audits</Link>
+                <Link href="https://docs.tracer.finance/security/audits-and-security" target="_blank" rel="noopener noreferrer">Security Audits</Link>
             </TextLinkContainer>
         </FooterContainer>
     )

--- a/src/organisms/Footer/Footer.tsx
+++ b/src/organisms/Footer/Footer.tsx
@@ -1,0 +1,111 @@
+// Generated with util/create-component.js
+import React from "react";
+import { Icon } from "../../atoms";
+import styled from "styled-components";
+import { device } from "../../helpers";
+import { FooterProps } from "./Footer.types";
+
+const Footer: React.FC<FooterProps> = () => {
+    const copyrightYear = new Date().getFullYear();
+    return (
+        <FooterContainer data-testid="Footer">
+            <span>
+                &copy; {copyrightYear} Tracer DAO
+            </span>
+            <SocialLinkContainer>
+                <Link href="https://docs.tracer.finance" target="_blank" rel="noreferrer">
+                    <Icon name="book" size="lg" />
+                </Link>
+                <Link href="https://discourse.tracer.finance" target="_blank" rel="noreferrer">
+                    <Icon name="discourse" size="lg" />
+                </Link>
+                <Link href="https://twitter.com/TracerDAO" target="_blank" rel="noreferrer">
+                    <Icon name="twitter" size="lg" />
+                </Link>
+                <Link href="https://github.com/tracer-protocol/perpetual-pools-contracts" target="_blank" rel="noreferrer">
+                    <Icon name="github" size="lg" />
+                </Link>
+                <Link href="https://discord.com/invite/kddBUqDVVb" target="_blank" rel="noreferrer">
+                    <Icon name="discord" size="lg" />
+                </Link>
+            </SocialLinkContainer>
+            <TextLinkContainer>
+                <Link href="https://tracer.finance/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</Link>
+                <Link href="https://tracer.finance/privacy-policy#terms-of-use" target="_blank" rel="noopener noreferrer">Terms of Use</Link>
+                <Link href="https://tracer.finance/privacy-policy#interfaces-disclaimer"  target="_blank" rel="noopener noreferrer">Disclaimer</Link>
+                <Link href="https://gateway.pinata.cloud/ipfs/QmS161WXV2bEAWUtdecfS5FYPmHQZdhNnjVFAwQ5FTX3og" target="_blank" rel="noopener noreferrer">Participation Agreement</Link>
+                <Link href="https://docs.tracer.finance/audits-and-security/perpetual-pools" target="_blank" rel="noopener noreferrer">Security Audits</Link>
+            </TextLinkContainer>
+        </FooterContainer>
+    )
+};
+
+const Link = styled.a`
+    font-family: ${(props) => props.theme.fontFamily.heading} !important;
+    font-size: 16px;
+    text-decoration-line: none;
+    color: ${({ theme }) => theme.colors.text.primary} !important;
+    opacity: 1;
+    transition-property: opacity;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+    &:hover {
+        opacity: .8;
+    }
+`
+
+const FooterContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 1rem;
+    margin: auto;
+    width: 100%;
+    @media ${device.mobileL} {
+        max-width: 540px;
+    }
+    @media ${device.tablet} {
+        max-width: 720px;
+    }
+    @media ${device.laptop} {
+        max-width: 960px;
+    }
+    @media ${device.desktop} {
+        max-width: 1140px;
+        flex-direction: row;
+    }
+    @media ${device.desktopL} {
+        max-width: 1320px;
+        flex-direction: row;
+    }
+`
+
+const SocialLinkContainer = styled.div`
+    display: flex;
+    gap: 0.75rem;
+    margin: 1.5rem 0rem;
+    @media ${device.desktop} {
+        margin: auto;
+    }
+    @media ${device.desktopL} {
+        margin: auto;
+    }
+`
+
+const TextLinkContainer = styled.div`
+    display: flex;
+    gap: 0.25rem;
+    flex-direction: column;
+    @media ${device.desktop} {
+        flex-direction: row;
+        gap: 0.75rem
+    }
+    @media ${device.desktopL} {
+        flex-direction: row;
+        gap: 0.75
+    }
+`
+
+export default Footer;
+

--- a/src/organisms/Footer/Footer.tsx
+++ b/src/organisms/Footer/Footer.tsx
@@ -8,35 +8,83 @@ const Footer: React.FC = () => {
     const copyrightYear = new Date().getFullYear();
     return (
         <FooterContainer data-testid="Footer">
-            <span>
-                &copy; {copyrightYear} Tracer DAO
-            </span>
+            <span>&copy; {copyrightYear} Tracer DAO</span>
             <SocialLinkContainer>
-                <Link href="https://docs.tracer.finance" target="_blank" rel="noreferrer">
+                <Link
+                    href="https://docs.tracer.finance"
+                    target="_blank"
+                    rel="noreferrer"
+                >
                     <Icon name="book" size="lg" />
                 </Link>
-                <Link href="https://discourse.tracer.finance" target="_blank" rel="noreferrer">
+                <Link
+                    href="https://discourse.tracer.finance"
+                    target="_blank"
+                    rel="noreferrer"
+                >
                     <Icon name="discourse" size="lg" />
                 </Link>
-                <Link href="https://twitter.com/TracerDAO" target="_blank" rel="noreferrer">
+                <Link
+                    href="https://twitter.com/TracerDAO"
+                    target="_blank"
+                    rel="noreferrer"
+                >
                     <Icon name="twitter" size="lg" />
                 </Link>
-                <Link href="https://github.com/tracer-protocol" target="_blank" rel="noreferrer">
+                <Link
+                    href="https://github.com/tracer-protocol"
+                    target="_blank"
+                    rel="noreferrer"
+                >
                     <Icon name="github" size="lg" />
                 </Link>
-                <Link href="https://discord.com/invite/kddBUqDVVb" target="_blank" rel="noreferrer">
+                <Link
+                    href="https://discord.com/invite/kddBUqDVVb"
+                    target="_blank"
+                    rel="noreferrer"
+                >
                     <Icon name="discord" size="lg" />
                 </Link>
             </SocialLinkContainer>
             <TextLinkContainer>
-                <Link href="https://tracer.finance/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</Link>
-                <Link href="https://tracer.finance/privacy-policy#terms-of-use" target="_blank" rel="noopener noreferrer">Terms of Use</Link>
-                <Link href="https://tracer.finance/privacy-policy#interfaces-disclaimer"  target="_blank" rel="noopener noreferrer">Disclaimer</Link>
-                <Link href="https://gateway.pinata.cloud/ipfs/QmS161WXV2bEAWUtdecfS5FYPmHQZdhNnjVFAwQ5FTX3og" target="_blank" rel="noopener noreferrer">Participation Agreement</Link>
-                <Link href="https://docs.tracer.finance/security/audits-and-security" target="_blank" rel="noopener noreferrer">Security Audits</Link>
+                <Link
+                    href="https://tracer.finance/privacy-policy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Privacy Policy
+                </Link>
+                <Link
+                    href="https://tracer.finance/privacy-policy#terms-of-use"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Terms of Use
+                </Link>
+                <Link
+                    href="https://tracer.finance/privacy-policy#interfaces-disclaimer"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Disclaimer
+                </Link>
+                <Link
+                    href="https://gateway.pinata.cloud/ipfs/QmS161WXV2bEAWUtdecfS5FYPmHQZdhNnjVFAwQ5FTX3og"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Participation Agreement
+                </Link>
+                <Link
+                    href="https://docs.tracer.finance/security/audits-and-security"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Security Audits
+                </Link>
             </TextLinkContainer>
         </FooterContainer>
-    )
+    );
 };
 
 const Link = styled.a`
@@ -49,9 +97,9 @@ const Link = styled.a`
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms;
     &:hover {
-        opacity: .8;
+        opacity: 0.8;
     }
-`
+`;
 
 const FooterContainer = styled.div`
     display: flex;
@@ -78,7 +126,7 @@ const FooterContainer = styled.div`
         max-width: 1320px;
         flex-direction: row;
     }
-`
+`;
 
 const SocialLinkContainer = styled.div`
     display: flex;
@@ -90,7 +138,7 @@ const SocialLinkContainer = styled.div`
     @media ${device.desktopL} {
         margin: auto;
     }
-`
+`;
 
 const TextLinkContainer = styled.div`
     display: flex;
@@ -98,13 +146,12 @@ const TextLinkContainer = styled.div`
     flex-direction: column;
     @media ${device.desktop} {
         flex-direction: row;
-        gap: 0.75rem
+        gap: 0.75rem;
     }
     @media ${device.desktopL} {
         flex-direction: row;
-        gap: 0.75
+        gap: 0.75;
     }
-`
+`;
 
 export default Footer;
-

--- a/src/organisms/Footer/Footer.types.ts
+++ b/src/organisms/Footer/Footer.types.ts
@@ -1,4 +1,0 @@
-
-// Generated with util/create-component.js
-export interface FooterProps {
-}

--- a/src/organisms/Footer/Footer.types.ts
+++ b/src/organisms/Footer/Footer.types.ts
@@ -1,0 +1,4 @@
+
+// Generated with util/create-component.js
+export interface FooterProps {
+}

--- a/src/organisms/Footer/index.ts
+++ b/src/organisms/Footer/index.ts
@@ -1,3 +1,2 @@
 // Generated with util/create-component.js
-export { FooterProps } from "./Footer.types";
 export { default as Footer } from "./Footer";

--- a/src/organisms/Footer/index.ts
+++ b/src/organisms/Footer/index.ts
@@ -1,0 +1,3 @@
+// Generated with util/create-component.js
+export { FooterProps } from "./Footer.types";
+export { default as Footer } from "./Footer";

--- a/src/organisms/index.ts
+++ b/src/organisms/index.ts
@@ -1,2 +1,3 @@
 export * from "./Navbar";
 export * from "./AssetAllocator";
+export * from "./Footer";


### PR DESCRIPTION
## Changelog

- add responsive `Footer` component under organism
- replace `gitbook` icon with `faBook` icon in `@fortawesome/free-solid-svg-icons`

## Demo

https://user-images.githubusercontent.com/31875755/169049861-81ad30df-446b-4e0a-ae31-299e284545a4.mp4



## Notes

- there is no `gitbook` icon found in the repository, thus I use `faBook` icon as a replacement.