### PR TITLE
Change tracer to mycelium for docs in footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tracer-protocol/tracer-ui",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "main": "build/index.js",
     "module": "build/index.esm.js",
     "files": [

--- a/src/organisms/Footer/Footer.tsx
+++ b/src/organisms/Footer/Footer.tsx
@@ -13,7 +13,7 @@ const Footer: React.FC = () => {
             </Text.Body>
             <SocialLinkContainer>
                 <Link
-                    href="https://docs.tracer.finance"
+                    href="https://swaps.docs.mycelium.xyz"
                     target="_blank"
                     rel="noreferrer"
                     className="footer-link"
@@ -39,7 +39,7 @@ const Footer: React.FC = () => {
                     />
                 </Link>
                 <Link
-                    href="https://twitter.com/TracerDAO"
+                    href="https://twitter.com/mycelium_xyz"
                     target="_blank"
                     rel="noreferrer"
                     className="footer-link"
@@ -52,7 +52,7 @@ const Footer: React.FC = () => {
                     />
                 </Link>
                 <Link
-                    href="https://github.com/tracer-protocol"
+                    href="https://github.com/mycelium-ethereum"
                     target="_blank"
                     rel="noreferrer"
                     className="footer-link"

--- a/src/organisms/Footer/Footer.tsx
+++ b/src/organisms/Footer/Footer.tsx
@@ -65,7 +65,7 @@ const Footer: React.FC = () => {
                     />
                 </Link>
                 <Link
-                    href="https://discord.com/invite/kddBUqDVVb"
+                    href="https://discord.gg/4pZUbXDZSF"
                     target="_blank"
                     rel="noreferrer"
                     className="footer-link"


### PR DESCRIPTION
## Changelog

- Change the docs link, github link, and Twitter link in the footer

## Notes

I understand that not all the URLs have been updated, but some I am not sure about (e.g. discourse) so I just left for now. Mostly making this PR cuz I'm getting hounded for the doc link to be updated.

Discord URL is set to never expire but would ideally have one of those "nice looking" URLs.